### PR TITLE
honami: use specific idProduct for usb paths

### DIFF
--- a/aosp_c6903.mk
+++ b/aosp_c6903.mk
@@ -42,5 +42,5 @@ PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=480
-
+    ro.sf.lcd_density=480 \
+    ro.usb.pid_suffix=19E


### PR DESCRIPTION
from 14.4.A.0.157

Signed-off-by: David Viteri <davidteri91@gmail.com>