### PR TITLE
honami: fix VoIP calls

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -466,6 +466,10 @@
         <ctl name="MultiMedia2 Mixer INTERNAL_FM_TX" value="1" />
     </path>
 
+    <path name="low-latency-record">
+        <ctl name="MultiMedia5 Mixer SLIM_0_TX" value="1" />
+    </path>
+
     <path name="voice-call">
         <ctl name="SLIM_0_RX_Voice Mixer CSVoice" value="1" />
         <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="1" />


### PR DESCRIPTION
tested with skype

logcat in skype call:

D/audio_hw_primary(  342): enable_snd_device: snd_device(23: handset-mic)
D/audio_hw_primary(  342): enable_audio_route: apply and update mixer path: low-latency-record
E/audio_route(  342): unable to find path 'low-latency-record'

Signed-off-by: David Viteri <davidteri91@gmail.com>