### PR TITLE
honami: re-add low-latency-record path

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -474,6 +474,10 @@
         <ctl name="MultiMedia2 Mixer INTERNAL_FM_TX" value="1" />
     </path>
 
+    <path name="low-latency-record">
+        <ctl name="MultiMedia5 Mixer SLIM_0_TX" value="1" />
+    </path>
+
     <path name="voice-call">
         <ctl name="SLIM_0_RX_Voice Mixer CSVoice" value="1" />
         <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="1" />


### PR DESCRIPTION
Needed for video calls on skype maybe others

was removed in commit: ef2f8aab8ed810c0a55bd3f5c9ea590d5b386cdf

E/audio_route(  342): unable to find path 'low-latency-record'

Signed-off-by: David Viteri <davidteri91@gmail.com>