### PR TITLE
Fix Incorrect Path

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -31,8 +31,8 @@
 		<!-- device-specific -->
 		<resource name="backlight" type="sysfs">/sys/class/leds/lcd-backlight/max_brightness</resource>
 
-		<resource name="temp-emmc" type="msm-adc">/sys/devices/00-vadc-3100/emmc_therm</resource>
-		<resource name="temp-batt" type="msm-adc">/sys/devices/00-vadc-3100/batt_therm</resource>
+		<resource name="temp-emmc" type="msm-adc">/sys/devices/qpnp-vadc-18/emmc_therm</resource>
+		<resource name="temp-batt" type="msm-adc">/sys/devices/qpnp-vadc-18/batt_therm</resource>
 		<resource name="kgsl-3d0" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
 		<resource name="dc" type="sysfs">/sys/class/power_supply/qpnp-dc/current_max</resource>
 		<resource name="usb" type="sysfs">/sys/class/power_supply/usb/current_max</resource>


### PR DESCRIPTION
There is no device 00-31, which produces multiple logcat spam: "fail to attach resource emmc_therm and batt_therm. As a result, sensors can't be read. The correct path is noted...